### PR TITLE
Add an alias for updateluma

### DIFF
--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -286,7 +286,7 @@ class Assistance(commands.Cog, command_attrs=dict(cooldown=commands.Cooldown(1, 
         embed.description = "A guide for updating to new B9S versions."
         await ctx.send(embed=embed)
 
-    @commands.command()
+    @commands.command(name = "updateluma", aliases = ["lumaupdate"])
     async def updateluma(self, ctx):
         """Links to the guide for updating Luma3DS manually (8.0 or later)"""
         embed = discord.Embed(title="Manually Updating Luma3DS", color=discord.Color(0xCE181E))


### PR DESCRIPTION
Adds an alias for the updateluma command so that it can also be triggered by typing .lumaupdate

<!--
* If adding words to the filter list in events.py, make sure all characters are lowercase and consist only of characters in Python [`string.printable`](https://docs.python.org/3/library/string.html).
-->