### PR TITLE
Create the “piracy” command

### DIFF
--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -275,7 +275,18 @@ class Assistance(commands.Cog, command_attrs=dict(cooldown=commands.Cooldown(1, 
                         - Dump your Wii U game discs to a format that can be installed on your internal or external Wii U storage drive.
                     """))
             await ctx.send(embed=embed)
-
+                               
+    @commands.command(aliases = ["pirate3", "whatisp")
+    async def piracy(self, ctx)
+        """Links to Eip's page on piracy"""
+        embed = discord.Embed(title="Eip's Piracy Page", color=discord.Color(0xCE181E))
+        embed.set_author(Name="eip", url = "https://3ds.eiphax.tech/piracy")
+        embed.set__thumbnail(url="https://nintendohomebrew.com/pics/nhplai.png")                         
+        embed.url = "https://3ds.eiphax.tech/piracy"
+        embed.description = "A link to Eip's page on what piracy is and what it constitutes"
+        await ctx.send(embed=embed)
+                                                                 
+                                 
     @commands.command()
     async def updateb9s(self, ctx):
         """Links to the guide for updating b9s versions"""


### PR DESCRIPTION
Creates a command called “piracy” with a few aliases that links directly to eip’s page on piracy

<!--
* If adding words to the filter list in events.py, make sure all characters are lowercase and consist only of characters in Python [`string.printable`](https://docs.python.org/3/library/string.html).
-->